### PR TITLE
Adding Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk8
+script: mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
+
 jdk:
   - oraclejdk8
-  - openjdk8
+  
 script: mvn clean verify


### PR DESCRIPTION
Only builds against oraclejdk8 as Java 8 is necessary and TravisCI does not include an openjdk8. See https://github.com/travis-ci/travis-ci/issues/1647 for details.