### PR TITLE
#40 add remove, recursive remove and remove children of node options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,19 @@
             <artifactId>jcommander</artifactId>
             <version>1.48</version>
         </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/main/java/net/imagini/zkcli/CliParameters.java
+++ b/src/main/java/net/imagini/zkcli/CliParameters.java
@@ -31,7 +31,7 @@ public class CliParameters {
     boolean deleteNodeNonRecursive;
 
     @Parameter(names = { "--rm-children" },
-            description = "Remove all children of a node recursively, keeping the node intact."
+            description = "Remove all children of a node recursively, keeping the specified node intact."
                     + "Requires a path and cluster")
     boolean deleteChildrenOfNode;
 

--- a/src/main/java/net/imagini/zkcli/CliParameters.java
+++ b/src/main/java/net/imagini/zkcli/CliParameters.java
@@ -22,6 +22,19 @@ public class CliParameters {
             description = "Print child nodes")
     boolean listChildren;
 
+    @Parameter(names = { "--rm-recursive", "-r" },
+            description = "Remove a node, deleting any children recursively if necessary. Requires a path and cluster")
+    boolean deleteNodeRecursive;
+
+    @Parameter(names = { "--rm" },
+            description = "Remove a node only if it does not have children. Requires a path and cluster")
+    boolean deleteNodeNonRecursive;
+
+    @Parameter(names = { "--rm-children" },
+            description = "Remove all children of a node recursively, keeping the node intact."
+                    + "Requires a path and cluster")
+    boolean deleteChildrenOfNode;
+
     @Parameter(names = { "--printPaths", "-p" },
             description = "When printing node names include full paths")
     boolean printPaths;
@@ -54,7 +67,8 @@ public class CliParameters {
     }
 
     public boolean includesAction() {
-        return listMetaAccessors || listChildren || getMeta || getData || help;
+        return listMetaAccessors || listChildren || deleteNodeRecursive || deleteNodeNonRecursive
+                || deleteChildrenOfNode || getMeta || getData || help;
     }
 
     void printUsage() {

--- a/src/test/java/net/imagini/zkcli/CliParametersTest.java
+++ b/src/test/java/net/imagini/zkcli/CliParametersTest.java
@@ -1,0 +1,28 @@
+package net.imagini.zkcli;
+
+import net.imagini.zkcli.CliParameters;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CliParametersTest {
+
+    private CliParameters underTest;
+
+    @Test
+    public void testIncludesAction() {
+        underTest = new CliParameters(new String[] { "--rm-recursive" });
+        Assert.assertTrue(underTest.includesAction());
+
+        underTest = new CliParameters(new String[] { "--rm" });
+        Assert.assertTrue(underTest.includesAction());
+
+        underTest = new CliParameters(new String[] { "--rm-children" });
+        Assert.assertTrue(underTest.includesAction());
+
+        underTest = new CliParameters(new String[] { "-p" });
+        Assert.assertFalse(underTest.includesAction());
+    }
+}

--- a/src/test/java/net/imagini/zkcli/ZkCliTest.java
+++ b/src/test/java/net/imagini/zkcli/ZkCliTest.java
@@ -1,0 +1,119 @@
+package net.imagini.zkcli;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.BackgroundVersionable;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.zookeeper.KeeperException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZkCliTest {
+
+    @Mock
+    private CuratorFramework client;
+
+    @Mock
+    private BackgroundVersionable backgroundVersionable;
+
+    @Mock
+    private DeleteBuilder deleteBuilder;
+
+    @Mock
+    private GetChildrenBuilder getChildrenBuilder;
+
+    @Mock
+    private CliParameters cliParameters;
+
+    private ZkCli underTest;
+
+    private static final String VALID_PATH = "/valid/path";
+
+    private static final String INVALID_PATH = "/invalid/path";
+
+    private List<String> validPathChildren;
+
+    @Before
+    public void setup() throws Exception {
+        underTest = new ZkCli(cliParameters);
+
+        validPathChildren = new ArrayList<>();
+        validPathChildren.add("child1");
+        validPathChildren.add("child2");
+        validPathChildren.add("child3");
+
+        Mockito.when(client.delete()).thenReturn(deleteBuilder);
+        Mockito.when(client.getChildren()).thenReturn(getChildrenBuilder);
+        Mockito.when(getChildrenBuilder.forPath(VALID_PATH)).thenReturn(validPathChildren);
+        Mockito.when(deleteBuilder.deletingChildrenIfNeeded()).thenReturn(backgroundVersionable);
+        Mockito.doThrow(KeeperException.NoNodeException.class)
+                .when(backgroundVersionable).forPath(Mockito.eq(INVALID_PATH));
+        Mockito.doThrow(KeeperException.NoNodeException.class)
+                .when(deleteBuilder).forPath(Mockito.eq(INVALID_PATH));
+    }
+
+    @Test
+    public void testDeleteNodeNonRecursiveNormal() throws Exception {
+        underTest.deleteNodeNonRecursive(client, VALID_PATH);
+
+        Mockito.verify(deleteBuilder, Mockito.times(1)).forPath(VALID_PATH);
+        Mockito.verifyNoMoreInteractions(deleteBuilder);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDeleteNodeNonRecursiveBadPath() {
+        underTest.deleteNodeNonRecursive(client, INVALID_PATH);
+    }
+
+    @Test
+    public void testDeleteNodeRecursiveNormal() throws Exception {
+        underTest.deleteNodeRecursive(client, VALID_PATH);
+
+        Mockito.verify(deleteBuilder, Mockito.times(1)).deletingChildrenIfNeeded();
+        Mockito.verify(backgroundVersionable, Mockito.times(1)).forPath(VALID_PATH);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDeleteNodeRecursiveBadPath() throws Exception {
+        underTest.deleteNodeRecursive(client, INVALID_PATH);
+    }
+
+    @Test
+    public void testDeleteChildrenNormal() throws Exception {
+        underTest.deleteChildrenOfNode(client, VALID_PATH);
+
+        Mockito.verify(deleteBuilder, Mockito.times(validPathChildren.size())).deletingChildrenIfNeeded();
+        Mockito.verify(backgroundVersionable, Mockito.times(validPathChildren.size())).forPath(Mockito.anyString());
+        Mockito.verify(backgroundVersionable, Mockito.times(0)).forPath(VALID_PATH);
+    }
+
+    @Test
+    public void testDeleteChildrenOfRoot() throws Exception {
+        validPathChildren.add("zookeeper");
+        Mockito.when(getChildrenBuilder.forPath("/")).thenReturn(validPathChildren);
+
+        underTest.deleteChildrenOfNode(client, "/");
+
+        Mockito.verify(deleteBuilder, Mockito.times(validPathChildren.size() - 1)).deletingChildrenIfNeeded();
+        Mockito.verify(backgroundVersionable, Mockito.times(validPathChildren.size() - 1)).forPath(Mockito.anyString());
+        Mockito.verify(backgroundVersionable, Mockito.times(0)).forPath("/zookeeper");
+    }
+
+    @Test
+    public void testDeleteChildrenWithNonRootZookeeperInPath() throws Exception {
+        validPathChildren.add("zookeeper");
+
+        underTest.deleteChildrenOfNode(client, VALID_PATH);
+
+        Mockito.verify(deleteBuilder, Mockito.times(validPathChildren.size())).deletingChildrenIfNeeded();
+        Mockito.verify(backgroundVersionable, Mockito.times(validPathChildren.size())).forPath(Mockito.anyString());
+    }
+}


### PR DESCRIPTION
Add ability to remove single node, remove recursively and remove children of specified node. No tests (yet). Will add once I know if it's okay from @feldoh to add JUnit and Mockito test dependencies.

### Example 1
`java -jar JZookeeperEdit.jar -z 127.0.0.1:2181 -r /zk_test`

Before:
```
/zk_test/child1
/zk_test/child2
/zookeeper
```
After:
```
/zookeeper
```

### Example 2
`java -jar JZookeeperEdit.jar -z 127.0.0.1:2181 --rm /zk_test`

Before:
```
/zk_test
/zookeeper
```
After:
```
/zookeeper
```

### Example 3
`java -jar target/JZookeeperEdit.jar -z 127.0.0.1:2181 --rm-children /zk_test`

Before:
```
/zk_test/child1
/zk_test/child2
/zk_test/child3/child1
```
After:
```
/zk_test
```

This isn't a full enumeration of all the cases (esp. the error ones), but I believe everything is handled in a reasonable manner.

*Note*: In some cases, such as removing all children from `/`, it is possible to encounter undefined behavior. Specifically, only the children before `/zookeeper` will be deleted and then an exception will be thrown when `/zookeeper` is passed to be deleted. The children following `/zookeeper` then, will not be deleted. I'm not quite sure what the behavior should be, so I left it for now. If there is a more concrete way this should be handled, let me know and I'll implement it.