### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>net.imagini.jzookeeperedit.fx.MainApp</mainClass>
-        <slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
     </properties>
 
     <organization>
@@ -23,12 +23,23 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
-            <version>2.11.0</version>
+            <version>4.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.4.13</version>
         </dependency>
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
-            <version>8.40.12</version>
+            <version>8.40.14</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -43,7 +54,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.58</version>
+            <version>1.72</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -55,13 +66,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.1.0</version>
+            <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>co.unruly</groupId>
             <artifactId>java-8-matchers</artifactId>
-            <version>1.1</version>
+            <version>1.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/imagini/zkcli/CliParameters.java
+++ b/src/main/java/net/imagini/zkcli/CliParameters.java
@@ -142,8 +142,9 @@ public class CliParameters {
      */
     public CliParameters(String[] args, ZkClusterManager clusterManager) {
         this.clusterManager = clusterManager;
-        argProcessor = new JCommander(this, args);
+        argProcessor = new JCommander(this);
         argProcessor.setProgramName(programName);
+        argProcessor.parse(args);
         blacklist.add("/zookeeper");
     }
 

--- a/src/test/java/net/imagini/jzookeeperedit/ZkNodeTest.java
+++ b/src/test/java/net/imagini/jzookeeperedit/ZkNodeTest.java
@@ -5,16 +5,18 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ZkNodeTest {
     private static final String NODE_LABEL = "someNode";
+
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/net/imagini/jzookeeperedit/ZkTreeNodeTest.java
+++ b/src/test/java/net/imagini/jzookeeperedit/ZkTreeNodeTest.java
@@ -12,27 +12,21 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ZkTreeNodeTest {
     private static final Charset CHARSET = java.nio.charset.StandardCharsets.UTF_8;
     private static final String NODE_NAME = "aNode";
@@ -40,8 +34,8 @@ public class ZkTreeNodeTest {
     private static final String VALID_PATH = "/valid/path";
     private static final String DATA = "Some very interesting\nDATA!!!!!!!";
 
-    private List<String> validPathChildren;
-
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -59,6 +53,7 @@ public class ZkTreeNodeTest {
     private GetChildrenBuilder mockGetChildrenBuilder;
 
     private ZkTreeNode unit;
+    private List<String> validPathChildren;
 
     @Before
     public void setup() throws Exception {

--- a/src/test/java/net/imagini/zkcli/CliParametersTest.java
+++ b/src/test/java/net/imagini/zkcli/CliParametersTest.java
@@ -1,32 +1,27 @@
 package net.imagini.zkcli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import com.beust.jcommander.ParameterException;
+import net.imagini.jzookeeperedit.ZkClusterManager;
+import org.apache.curator.framework.CuratorFramework;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.*;
 
-import net.imagini.jzookeeperedit.ZkClusterManager;
-
-import com.beust.jcommander.ParameterException;
-
-@RunWith(MockitoJUnitRunner.class)
 public class CliParametersTest {
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
+
     @Mock
     private CuratorFramework mockClient;
     @Mock

--- a/src/test/java/net/imagini/zkcli/ZkCliTest.java
+++ b/src/test/java/net/imagini/zkcli/ZkCliTest.java
@@ -1,14 +1,14 @@
 package net.imagini.zkcli;
 
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.apache.curator.framework.CuratorFramework;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.io.PrintStream;
 import java.lang.reflect.Field;
@@ -19,18 +19,16 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ZkCliTest {
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/src/test/java/net/imagini/zkcli/ZkDeleteHandlerTest.java
+++ b/src/test/java/net/imagini/zkcli/ZkDeleteHandlerTest.java
@@ -1,32 +1,29 @@
 package net.imagini.zkcli;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundVersionable;
 import org.apache.curator.framework.api.DeleteBuilder;
 import org.apache.curator.framework.api.GetChildrenBuilder;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-@RunWith(MockitoJUnitRunner.class)
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
 public class ZkDeleteHandlerTest {
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
 
     @Mock
     private CuratorFramework client;

--- a/src/test/java/net/imagini/zkcli/ZkMetadataHandlerTest.java
+++ b/src/test/java/net/imagini/zkcli/ZkMetadataHandlerTest.java
@@ -1,16 +1,5 @@
 package net.imagini.zkcli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ExistsBuilder;
 import org.apache.curator.framework.api.GetChildrenBuilder;
@@ -18,13 +7,24 @@ import org.apache.curator.framework.api.GetDataBuilder;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-@RunWith(MockitoJUnitRunner.class)
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
 public class ZkMetadataHandlerTest {
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
+
     @Mock
     private CuratorFramework client;
 

--- a/src/test/java/net/imagini/zkcli/ZkReadHandlerTest.java
+++ b/src/test/java/net/imagini/zkcli/ZkReadHandlerTest.java
@@ -1,28 +1,29 @@
 package net.imagini.zkcli;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-
+import co.unruly.matchers.StreamMatchers;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ExistsBuilder;
 import org.apache.curator.framework.api.GetChildrenBuilder;
 import org.apache.curator.framework.api.GetDataBuilder;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-import co.unruly.matchers.StreamMatchers;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 
-@RunWith(MockitoJUnitRunner.class)
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
 public class ZkReadHandlerTest {
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
 
     @Mock
     private CuratorFramework client;


### PR DESCRIPTION
New version of curator works with old zookeeper by explicitly importing the old version instead