### PR TITLE
Make plugins execute again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     curl -LJ "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-java11-$DOWNLOAD_OS_NAME-amd64-$GRAALVM_VERSION.tar.gz" --output graalvm.tar.gz
     tar -vxzf graalvm.tar.gz
 script:
-  - export GRAALVM_HOME="$(pwd)/graalvm-ce-$GRAALVM_VERSION" && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GRAALVM_HOME="$JAVA_HOME/Contents/Home"; fi
+  - export GRAALVM_HOME="$(pwd)/graalvm-ce-$GRAALVM_VERSION" && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GRAALVM_HOME="$GRAALVM_HOME/Contents/Home"; fi
   - mvn clean verify
   - mvn package
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     curl -LJ "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-java11-$DOWNLOAD_OS_NAME-amd64-$GRAALVM_VERSION.tar.gz" --output graalvm.tar.gz
     tar -vxzf graalvm.tar.gz
 script:
-  - export GRAALVM_HOME="$(pwd)/graalvm-ce-$GRAALVM_VERSION" && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GRAALVM_HOME="$GRAALVM_HOME/Contents/Home"; fi
+  - export GRAALVM_HOME="$(pwd)/graalvm-ce-java11-$GRAALVM_VERSION" && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export GRAALVM_HOME="$GRAALVM_HOME/Contents/Home"; fi
   - mvn clean verify
   - mvn package
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,6 @@
                 <configuration>
                     <target>host</target>
                     <mainClass>${mainClass}</mainClass>
-                    <graalvmHome>C:\Program Files\Java\graalvm-ce-java11-20.2.0</graalvmHome>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.imagini</groupId>
@@ -9,12 +10,12 @@
 
     <name>JZookeeperEdit</name>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<mainClass>net.imagini.jzookeeperedit.fx.MainApp</mainClass>
-		<slf4j.version>1.7.25</slf4j.version>
-		<java.version>11</java.version>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mainClass>net.imagini.jzookeeperedit.fx.MainApp</mainClass>
+        <slf4j.version>1.7.25</slf4j.version>
+        <java.version>11</java.version>
+    </properties>
 
     <organization>
         <name>VisualDNA</name>
@@ -37,17 +38,17 @@
             <artifactId>zookeeper</artifactId>
             <version>3.4.13</version>
         </dependency>
-		<dependency>
-		    <groupId>org.openjfx</groupId>
-		    <artifactId>javafx-controls</artifactId>
-		    <version>11</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.openjfx</groupId>
-		    <artifactId>javafx-fxml</artifactId>
-		    <version>11</version>
-		</dependency>
-		<dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11</version>
+        </dependency>
+        <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
             <version>11.0.0</version>
@@ -93,149 +94,134 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <finalName>${project.artifactId}</finalName>
-        <pluginManagement>
-	        <plugins>
-	            <plugin>
-	                <groupId>org.apache.maven.plugins</groupId>
-	                <artifactId>maven-compiler-plugin</artifactId>
-	                <version>3.8.0</version>
-	                <configuration>
-        				<release>${java.version}</release>
-	                    <source>${java.version}</source>
-	                    <target>${java.version}</target>
-	                    <showDeprecation>true</showDeprecation>
-	                </configuration>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.apache.maven.plugins</groupId>
-	                <artifactId>maven-surefire-plugin</artifactId>
-	                <version>3.0.0-M3</version>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.apache.maven.plugins</groupId>
-	                <artifactId>maven-checkstyle-plugin</artifactId>
-	                <version>3.1.0</version>
-	                <executions>
-	                    <execution>
-	                        <id>validate</id>
-	                        <phase>validate</phase>
-	                        <configuration>
-	                            <configLocation>src/main/resources/checkstyle.xml</configLocation>
-	                            <encoding>UTF-8</encoding>
-	                            <consoleOutput>true</consoleOutput>
-	                            <failsOnError>true</failsOnError>
-	                            <failOnViolation>true</failOnViolation>
-	                            <logViolationsToConsole>true</logViolationsToConsole>
-	                            <violationSeverity>info</violationSeverity>
-	                        </configuration>
-	                        <goals>
-	                            <goal>check</goal>
-	                            <goal>checkstyle</goal>
-	                        </goals>
-	                    </execution>
-	                </executions>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.codehaus.mojo</groupId>
-	                <artifactId>findbugs-maven-plugin</artifactId>
-	                <version>3.0.5</version>
-	                <executions>
-	                    <execution>
-	                        <id>findbugs</id>
-	                        <phase>process-test-resources</phase>
-	                        <goals>
-	                            <goal>check</goal>
-	                        </goals>
-	                        <configuration>
-	                            <threshold>Low</threshold>
-	                        </configuration>
-	                    </execution>
-	                </executions>
-	            </plugin>
-	            <plugin>
-			        <groupId>org.openjfx</groupId>
-			        <artifactId>javafx-maven-plugin</artifactId>
-			        <version>0.0.3</version>
-			        <configuration>
-	                    <identifier>${project.name}</identifier>
-	                    <needMenu>true</needMenu>
-	                    <mainClass>${mainClass}</mainClass>
-	                    <appName>${project.name}</appName>
-	                    <nativeReleaseVersion>${project.version}</nativeReleaseVersion>
-	                </configuration>
-	                <executions>
-	                    <execution>
-	                        <!-- required before build-native -->
-	                        <id>create-jfxjar</id>
-	                        <phase>package</phase>
-	                        <goals>
-	                            <goal>build-jar</goal>
-	                        </goals>
-	                    </execution>
-	                    <execution>
-	                        <id>create-native</id>
-	                        <phase>package</phase>
-	                        <goals>
-	                            <goal>build-native</goal>
-	                        </goals>
-	                    </execution>
-	                </executions>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.jacoco</groupId>
-	                <artifactId>jacoco-maven-plugin</artifactId>
-	                <version>0.8.2</version>
-	                <executions>
-	                    <execution>
-	                        <id>prepare-agent</id>
-	                        <goals>
-	                            <goal>prepare-agent</goal>
-	                        </goals>
-	                    </execution>
-	                    <execution>
-	                        <id>report</id>
-	                        <phase>test</phase>
-	                        <goals>
-	                            <goal>report</goal>
-	                        </goals>
-	                    </execution>
-	                </executions>
-	                <configuration>
-	                    <excludes>
-	                        <exclude>net/imagini/jzookeeperedit/fx/**</exclude>
-	                    </excludes>
-	                </configuration>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.eluder.coveralls</groupId>
-	                <artifactId>coveralls-maven-plugin</artifactId>
-	                <version>4.3.0</version>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.apache.maven.plugins</groupId>
-	                <artifactId>maven-enforcer-plugin</artifactId>
-	                <version>3.0.0-M2</version>
-	                <executions>
-	                    <execution>
-	                        <id>enforce-maven</id>
-	                        <goals>
-	                            <goal>enforce</goal>
-	                        </goals>
-	                        <configuration>
-	                            <rules>
-	                                <requireMavenVersion>
-	                                    <version>[3.3.9,)</version>
-	                                </requireMavenVersion>
-	                            </rules>
-	                        </configuration>
-	                    </execution>
-	                </executions>
-	            </plugin>
-	        </plugins>
-		</pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <configLocation>src/main/resources/checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <failOnViolation>true</failOnViolation>
+                            <logViolationsToConsole>true</logViolationsToConsole>
+                            <violationSeverity>info</violationSeverity>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.1.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.5</version>
+                <configuration>
+                    <mainClass>${mainClass}</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.gluonhq</groupId>
+                <artifactId>client-maven-plugin</artifactId>
+                <version>0.1.33</version>
+                <configuration>
+                    <target>host</target>
+                    <mainClass>${mainClass}</mainClass>
+                    <graalvmHome>C:\Program Files\Java\graalvm-ce-java11-20.2.0</graalvmHome>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>net/imagini/jzookeeperedit/fx/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.3.9,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <reporting>
         <plugins>


### PR DESCRIPTION
All plugins were moved into dependency management and so weren't running. This restores them to working order and upgrades where necessary to make everything compile and run successfully.

This also involves changing travis builds etc as Gluon requires GraalVM to compile native images.